### PR TITLE
Update where we search for CaC products

### DIFF
--- a/ctf/DiffStruct.py
+++ b/ctf/DiffStruct.py
@@ -38,16 +38,18 @@ class DiffStruct:
     def find_rule_profiles(self, rule):
         product_folders = []
 
-        # Walk through project folder and
-        # find all folders with subfolder "profiles" (=product folder)
-        for content_file in os.listdir(git_wrapper.repo_path):
-            subfolder = git_wrapper.repo_path + "/" + content_file
-            if not os.path.isdir(subfolder):
+        # We know that products are in products/ folder
+        # We want all products' paths
+        products_folder = git_wrapper.repo_path + "/" + "products"
+        for product_name in os.listdir(products_folder):
+            product_path = products_folder + "/" + product_name
+            if not os.path.isdir(product_path):
                 continue
 
-            for subfile in os.listdir(subfolder):
+            for subfile in os.listdir(product_path):
                 if subfile == "profiles":
-                    product_folders.append(subfolder)
+                    product_folders.append(product_path)
+                    continue
 
         find_rule = re.compile(r"^\s*-\s*" + rule + r"\s*$")
         # Create list of all profiles that contain the rule

--- a/ctf/analysis/ProfileAnalysis.py
+++ b/ctf/analysis/ProfileAnalysis.py
@@ -17,15 +17,15 @@ class ProfileAnalysis(AbstractAnalysis):
         super().__init__(file_record)
         self.diff_struct.file_type = FileType.PROFILE
         path = self.filepath.split("/")
-        # format: PRODUCT/profiles/PROFILE.profile
-        self.product = path[0]
+        # format: products/PRODUCT/profiles/PROFILE.profile
+        self.product = path[1]
         self.profile = path[-1].split(".")[0]
         self.added_rules = []
         self.removed_rules = []
 
     @staticmethod
     def can_analyse(filepath):
-        if filepath.endswith(".profile"):
+        if filepath.endswith(".profile") and not filepath.startswith("tests/"):
             return True
         return False
 

--- a/tests/jinja.bats
+++ b/tests/jinja.bats
@@ -9,8 +9,8 @@ prepare_repository
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
     regex_check_1="build_product"
     regex_check_2="test_suite.py rule.*sshd_use_strong_macs"
-    regex_check_3="test_suite.py rule.*sshd_set_loglevel_info"
-    regex_check_4="test_suite.py rule.*sshd_disable_rhosts"
+    regex_check_3="test_suite.py rule.*sshd_set_idle_timeout"
+    regex_check_4="test_suite.py rule.*sshd_use_priv_separation"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Change documentation_complete" {
-    file="rhel8/profiles/ospp.profile"
+    file="products/rhel8/profiles/ospp.profile"
     sed -i 's/documentation_complete: true/documentation_complete: false/' "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -21,7 +21,7 @@ prepare_repository
 }
 
 @test "Change title" {
-    file="rhel8/profiles/ospp.profile"
+    file="products/rhel8/profiles/ospp.profile"
     sed -i "s/title: .*/title: 'Some title'/" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -37,7 +37,7 @@ prepare_repository
 }
 
 @test "Add new category" {
-    file="rhel8/profiles/ospp.profile"
+    file="products/rhel8/profiles/ospp.profile"
     echo >> "$file"
     sed -i "\$asome_category: 'with_string'" "$file"
     regex_check="build_product "
@@ -56,7 +56,7 @@ prepare_repository
 }
 
 @test "Change rule (= adding new rule and removing old one)" {
-    file="rhel8/profiles/ospp.profile"
+    file="products/rhel8/profiles/ospp.profile"
     sed -i 's/disable_host_auth/enable_host_auth/' "$file"
     regex_check_1="build_product "
     regex_check_2="test_suite\.py profile.*ospp"
@@ -79,7 +79,7 @@ prepare_repository
 }
 
 @test "Remove profile" {
-    file="rhel8/profiles/ospp.profile"
+    file="products/rhel8/profiles/ospp.profile"
     rm -f "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -95,8 +95,8 @@ prepare_repository
 }
 
 @test "Add new profile" {
-    file="rhel8/profiles/some_profile.profile"
-    cat "rhel8/profiles/ospp.profile" > "$file"
+    file="products/rhel8/profiles/some_profile.profile"
+    cat "products/rhel8/profiles/ospp.profile" > "$file"
     regex_check_1="build_product "
     regex_check_2="test_suite\.py profile.*some_profile"
 


### PR DESCRIPTION
Products were moved under `products/` directory.

Testing:
1. Created branch in content repository
2. Changed `linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml`
3. `$ python3 content_test_filtering.py branch --local --repository /home/mlysonek/SCAP/content test_branch`

Before:
```
Changes identified:
  Rules:
    rpm_verify_ownership

  Rule rpm_verify_ownership:
    Ansible remediation changed.
    The rule doesn't occur in any profile nor product.
```

After:
```
Changes identified:
  Rules:
    rpm_verify_ownership

  Rule rpm_verify_ownership:
    Ansible remediation changed.


Recommended tests to execute:
    build_product rhel8
    tests/test_suite.py rule --libvirt qemu:///system test-suite-vm --remediate-using ansible --datastream build/ssg-rhel8-ds.xml rpm_verify_ownership
```