### PR TITLE
JSON format output, OVAL change selects bash and ansbile remediations

### DIFF
--- a/content_test_filtering.py
+++ b/content_test_filtering.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
                          "performed for it.", file_record["filepath"])
             continue
 
-        tests.fill_tests(diff_structure)
+        tests.fill_tests(diff_structure, options.profile_output, options.rule_output)
         logs.fill_logging(diff_structure)
         already_analysed.append(file_record["filepath"])
         # If change affected any other file -> analyse it

--- a/content_test_filtering.py
+++ b/content_test_filtering.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     options = cli.parse_args()
     already_analysed = []
     list_of_tests = []
-    tests = ContentTests.ContentTests()
+    tests = ContentTests.ContentTests(options.output)
     logs = DiffLogging.DiffLogging()
 
     if options.output_tests:
@@ -53,7 +53,10 @@ if __name__ == '__main__':
         # If change affected any other file -> analyse it
         changed_files.extend(diff_structure.affected_files)
 
-    list_of_tests = connect_to_labels.get_labels(tests)
-    logs.print_all_logs(list_of_tests, output_format=options.output_format)
+    list_of_tests = connect_to_labels.get_labels(tests, options.output)
+    if options.output == "json":
+        logs.print_json(list_of_tests)
+    else:
+        logs.print_all_logs(list_of_tests, output_format=options.output_format)
 
     logger.debug("Finished")

--- a/ctf/ContentTests.py
+++ b/ctf/ContentTests.py
@@ -180,12 +180,25 @@ class ContentTests:
         self.test_classes.append(product_build)
 
     def add_profile_test(self, path, product, profile):
-        profile_test = ProfileTest(path, profile, product)
+        for test_class in self.test_classes:
+            if not isinstance(test_class, ProfileTest):
+                continue
+            if test_class.product == product:
+                test_class.profiles_list.append(profile)
+                return
+        profile_test = ProfileTest(path, profile, product, self.output)
         self.products_affected.add(product)
         self.test_classes.append(profile_test)
 
-    def add_rule_test(self, path, product, rule, remediation="bash"):
-        rule_test = RulesTest(path, product, [rule], remediation)
+    def add_rule_test(self, path, product, rule, remediation={"bash"}):
+        for test_class in self.test_classes:
+            if not isinstance(test_class, RulesTest):
+                continue
+            if test_class.product == product and \
+                    remediation.issubset(test_class.remediations):
+                test_class.rules_list.append(rule)
+                return
+        rule_test = RulesTest(path, product, [rule], self.output, remediation)
         self.products_affected.add(product)
         self.test_classes.append(rule_test)
 

--- a/ctf/ContentTests.py
+++ b/ctf/ContentTests.py
@@ -139,7 +139,8 @@ class LintTest(AbstractTest):
 
 
 class ContentTests:
-    def __init__(self):
+    def __init__(self, output="commands"):
+        self.output = output
         self.products_affected = set()
         self.test_classes = []
 
@@ -159,10 +160,16 @@ class ContentTests:
 
         for product, rule in diff_struct.get_changed_rules_with_products():
             self.add_rule_test(diff_struct.absolute_path, product, rule,
-                               remediation_type)
+                               remediation_types)
 
         for product, profile in diff_struct.get_changed_profiles_with_products():
             self.add_profile_test(diff_struct.absolute_path, product, profile)
+
+        if self.output == "json":
+            return
+
+        for product in diff_struct.changed_products:
+            self.add_product_build(diff_struct.absolute_path, product)
 
         if diff_struct.funcionality_changed:
             self.add_python_test(diff_struct.absolute_path)

--- a/ctf/ContentTests.py
+++ b/ctf/ContentTests.py
@@ -77,17 +77,36 @@ class RulesTest(AbstractTest):
         return tests
 
 class ProfileTest(AbstractTest):
-    def __init__(self, path, profile, product):
+    def __init__(self, path, profile, product, output):
         super().__init__(path, product)
-        self.profile = profile
+        self.output = output
+        self.profiles_list = [profile]
 
     def get_tests(self, yaml_content):
         tests = []
+        if self.output == "json":
+            tests = self.test_json(yaml_content)
+        else:
+            tests = self.test_command(yaml_content)
+        return tests
 
-        profile = yaml_content["profile"]
-        profile = self.translate_variable(profile, "%profile_name%", self.profile)
-        tests.append(profile)
+    def test_command(self, yaml_content):
+        tests = []
+        for profile_name in self.profiles_list:
+            profile_test = yaml_content["profile"]
+            profile = self.translate_variable(profile_test, "%profile_name%",
+                                              profile_name)
+            tests.append(profile)
+        return tests
 
+    def test_json(self, yaml_content):
+        profiles_tests = yaml_content["json_profile"]
+        profiles = ", ".join('"' + profile + '"' for profile in self.profiles_list)
+        profiles_tests = self.translate_variable(profiles_tests,
+                                                 "%profile_name%", profiles)
+        import json
+        profiles = json.loads(profiles_tests)
+        tests = [profiles]
         return tests
 
 

--- a/ctf/ContentTests.py
+++ b/ctf/ContentTests.py
@@ -110,11 +110,14 @@ class ContentTests:
         self.profiles = []
 
     def fill_tests(self, diff_struct):
-        remediation_type = "ansible" if diff_struct.file_type == FileType.YAML\
-                                     else "bash"
-
-        for product in diff_struct.changed_products:
-            self.add_product_build(diff_struct.absolute_path, product)
+        remediation_types = set()
+        if diff_struct.file_type == FileType.YAML:
+            remediation_types.add("ansible")
+        elif diff_struct.file_type == FileType.OVAL or diff_struct.file_type == FileType.JINJA:
+            remediation_types.add("ansible")
+            remediation_types.add("bash")
+        else:
+            remediation_types.add("bash")
 
         for product, rule in diff_struct.get_changed_rules_with_products():
             self.add_rule_test(diff_struct.absolute_path, product, rule,

--- a/ctf/ContentTests.py
+++ b/ctf/ContentTests.py
@@ -59,7 +59,7 @@ class RulesTest(AbstractTest):
         for rule in self.rules_list:
             for remediation_type in self.remediations:
                 rule_test = yaml_content["rule_" + remediation_type]
-                rule_test = self.translate_variable(rule, "%rule_name%", rule_test)
+                rule_test = self.translate_variable(rule_test, "%rule_name%", rule)
                 tests.append(rule_test)
         return tests
 

--- a/ctf/DiffLogging.py
+++ b/ctf/DiffLogging.py
@@ -110,6 +110,10 @@ class DiffLogging:
                 print("%s%s" % (format_style["list_prefix"], test),
                       end=format_style["end_line"])
 
+    def print_json(self, tests=None):
+        for test in tests:
+            print(test)
+
     def add_rule_log(self, rule, msgs):
         for msg in msgs:
             if rule in self.rules:

--- a/ctf/DiffLogging.py
+++ b/ctf/DiffLogging.py
@@ -111,8 +111,9 @@ class DiffLogging:
                       end=format_style["end_line"])
 
     def print_json(self, tests=None):
+        import json
         for test in tests:
-            print(test)
+            print(json.dumps(test))
 
     def add_rule_log(self, rule, msgs):
         for msg in msgs:

--- a/ctf/cli.py
+++ b/ctf/cli.py
@@ -30,6 +30,9 @@ def parse_args():
     common_parser.add_argument("--output-format", dest="output_format", default="raw",
                                action="store", choices=["raw", "markdown"],
                                help="Output format.")
+    common_parser.add_argument("--output", dest="output", default="commands",
+                               action="store", choices=["commands", "json"],
+                               help="Output from the tool.")
 
     parser.set_defaults(pr_number=None, branch=None)
 

--- a/ctf/cli.py
+++ b/ctf/cli.py
@@ -33,6 +33,10 @@ def parse_args():
     common_parser.add_argument("--output", dest="output", default="commands",
                                action="store", choices=["commands", "json"],
                                help="Output from the tool.")
+    common_parser.add_argument("--profile", dest="profile_output", default=False,
+                               action="store_true", help="Print only profile tests.")
+    common_parser.add_argument("--rule", dest="rule_output", default=False,
+                               action="store_true", help="Print only rule tests.")
 
     parser.set_defaults(pr_number=None, branch=None)
 

--- a/ctf/connect_to_labels.py
+++ b/ctf/connect_to_labels.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("content-test-filtering.connect_to_labels")
 TEST_LABELS = "test_labels.yml"
 
 
-def get_labels(content_tests):
+def get_labels(content_tests, output="commands"):
     template_loader = jinja2.FileSystemLoader(
                         searchpath=str(Path(__file__).parent / ".."))
     template_env = jinja2.Environment(loader=template_loader, autoescape=True)
@@ -21,7 +21,7 @@ def get_labels(content_tests):
             product=product
         ))
 
-        if product != "no_product":
+        if product != "no_product" and output == "commands":
             product_build = yaml_content["prepare_product"]
             tests.append(product_build)
 

--- a/test_labels.yml
+++ b/test_labels.yml
@@ -17,3 +17,17 @@ jinja: jinjalint
 profile: tests/test_suite.py profile {{ target }} --datastream {{ datastream_file }} %profile_name%
 rule_ansible: tests/test_suite.py rule {{ target }} --remediate-using ansible --datastream {{ datastream_file }} %rule_name%
 rule_bash: tests/test_suite.py rule {{ target }} --remediate-using bash --datastream {{ datastream_file }} %rule_name%
+
+json_rule: |
+  {
+    "rules": [ %rule_name% ],
+     "product": "{{ product }}",
+     "bash": "False",
+     "ansible": "False"
+  }
+
+json_profile: |
+  {
+    "profiles": [ %profile_name% ],
+    "product": "{{ product }}"
+  }

--- a/tests/json_ansible.bats
+++ b/tests/json_ansible.bats
@@ -56,7 +56,7 @@ prepare_repository
 @test "Change remediation part" {
     file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
     sed -i 's;path: .*;path: /some/path/;' "$file"
-    regex_check="{.*'rules': \['disable_prelink'\].*'bash': 'False'.*'ansible': 'True'}"
+    regex_check='{.*"rules": \["disable_prelink"\].*"bash": "False".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -73,7 +73,7 @@ prepare_repository
 @test "Change templated remediation" {
     file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml"
     sed -i 's/ansible_sshd_set/ansible_some_template/' "$file"
-    regex_check="{.*'rules': \['sshd_use_approved_macs'\].*'bash': 'False'.*'ansible': 'True'}"
+    regex_check='{.*"rules": \["sshd_use_approved_macs"\].*"bash": "False".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -107,7 +107,7 @@ prepare_repository
     file="./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml"
     mkdir -p "./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/"
     echo "echo \"IgnoreRhosts yes\" > /tmp/ssh_tmp_file" > "$file"
-    regex_check="{.*'rules': \['sshd_disable_rhosts'\].*'bash': 'False'.*'ansible': 'True'}"
+    regex_check='{.*"rules": \["sshd_disable_rhosts"\].*"bash": "False".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_ansible.bats
+++ b/tests/json_ansible.bats
@@ -1,0 +1,122 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+
+@test "Add comment line" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    sed -i "\$a# comment" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change metadata" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    sed -i 's/# reboot = false/# reboot = true/' "$file"
+    regex_check="build_product "
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change name" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    sed -i 's/- name: disable.*/- name: some name/' "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change remediation part" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    sed -i 's;path: .*;path: /some/path/;' "$file"
+    regex_check="{.*'rules': \['disable_prelink'\].*'bash': 'False'.*'ansible': 'True'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change templated remediation" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml"
+    sed -i 's/ansible_sshd_set/ansible_some_template/' "$file"
+    regex_check="{.*'rules': \['sshd_use_approved_macs'\].*'bash': 'False'.*'ansible': 'True'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Remove ansible remediation" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml"
+    rm -f "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add new ansible remediation" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml"
+    mkdir -p "./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/"
+    echo "echo \"IgnoreRhosts yes\" > /tmp/ssh_tmp_file" > "$file"
+    regex_check="{.*'rules': \['sshd_disable_rhosts'\].*'bash': 'False'.*'ansible': 'True'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}

--- a/tests/json_bash.bats
+++ b/tests/json_bash.bats
@@ -39,7 +39,7 @@ prepare_repository
 @test "Change remediation" {
     file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
     sed -i "s/chmod 600/chmod 744/" "$file"
-    regex_check="{.*'rules': \['sssd_run_as_sssd_user'\].*'bash': 'True'.*'ansible': 'False'}"
+    regex_check='{.*"rules": \["sssd_run_as_sssd_user"\].*"bash": "True".*"ansible": "False"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -56,7 +56,7 @@ prepare_repository
 @test "Change templated remediation" {
     file="./linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/bash/shared.sh"
     sed -i "s/bash_sshd_config_set/bash_some_template/" "$file"
-    regex_check="{.*'rules': \['sshd_use_strong_ciphers'\].*'bash': 'True'.*'ansible': 'False'}"
+    regex_check='{.*"rules": \["sshd_use_strong_ciphers"\].*"bash": "True".*"ansible": "False"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -91,7 +91,7 @@ prepare_repository
     file="./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/bash/shared.sh"
     mkdir -p "./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/bash/"
     echo "echo \"IgnoreRhosts yes\" > /tmp/ssh_tmp_file" > "$file"
-    regex_check="{.*'rules': \['sshd_disable_rhosts'\].*'bash': 'True'.*'ansible': 'False'}"
+    regex_check='{.*"rules": \["sshd_disable_rhosts"\].*"bash": "True".*"ansible": "False"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_bash.bats
+++ b/tests/json_bash.bats
@@ -1,0 +1,106 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+
+@test "Add comment line" {
+    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
+    sed -i "\$a# comment" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not emtpy" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change indetation" {
+    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
+    sed -i "s/\s*touch \$SSSD_CONF/touch \$SSSD_CONF/" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not emtpy" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change remediation" {
+    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
+    sed -i "s/chmod 600/chmod 744/" "$file"
+    regex_check="{.*'rules': \['sssd_run_as_sssd_user'\].*'bash': 'True'.*'ansible': 'False'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change templated remediation" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/bash/shared.sh"
+    sed -i "s/bash_sshd_config_set/bash_some_template/" "$file"
+    regex_check="{.*'rules': \['sshd_use_strong_ciphers'\].*'bash': 'True'.*'ansible': 'False'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+
+@test "Remove bash remediation" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh"
+    rm -f "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not emtpy" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add new bash remediation" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/bash/shared.sh"
+    mkdir -p "./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/bash/"
+    echo "echo \"IgnoreRhosts yes\" > /tmp/ssh_tmp_file" > "$file"
+    regex_check="{.*'rules': \['sshd_disable_rhosts'\].*'bash': 'True'.*'ansible': 'False'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}

--- a/tests/json_jinja.bats
+++ b/tests/json_jinja.bats
@@ -7,10 +7,10 @@ prepare_repository
 @test "Change sshd macro" {
     file="./shared/macros-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
-    regex_check_1="{.*'rules': \[.*'sshd_use_strong_ciphers'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
-    regex_check_2="{.*'rules': \[.*'sshd_use_strong_macs'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
-    regex_check_3="{.*'rules': \[.*'sshd_set_keepalive'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
-    regex_check_4="{.*'rules': \[.*'sshd_set_idle_timeout'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
+    regex_check_1='{.*"rules": \[.*"sshd_use_strong_ciphers".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_2='{.*"rules": \[.*"sshd_use_strong_macs".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_3='{.*"rules": \[.*"sshd_set_keepalive".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_4='{.*"rules": \[.*"sshd_set_idle_timeout".*\].*"bash": "True".*"ansible": "False".*}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_jinja.bats
+++ b/tests/json_jinja.bats
@@ -1,0 +1,38 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+
+@test "Change sshd macro" {
+    file="./shared/macros-bash.jinja"
+    sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
+    regex_check_1="{.*'rules': \[.*'sshd_use_strong_ciphers'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
+    regex_check_2="{.*'rules': \[.*'sshd_use_strong_macs'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
+    regex_check_3="{.*'rules': \[.*'sshd_set_keepalive'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
+    regex_check_4="{.*'rules': \[.*'sshd_set_idle_timeout'.*\].*'bash': 'True'.*'ansible': 'False'.*}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check_1" "$tmp_file"; then
+        echo "$regex_check_1 not found in:" && cat "$tmp_file"
+        return 1
+    fi
+    if ! grep -q "$regex_check_2" "$tmp_file"; then
+        echo "$regex_check_2 not found in:" && cat "$tmp_file"
+        return 1
+    fi
+    if ! grep -q "$regex_check_3" "$tmp_file"; then
+        echo "$regex_check_3 not found in:" && cat "$tmp_file"
+        return 1
+    fi
+    if ! grep -q "$regex_check_4" "$tmp_file"; then
+        echo "$regex_check_4 not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+

--- a/tests/json_oval.bats
+++ b/tests/json_oval.bats
@@ -1,0 +1,89 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+
+@test "Add comment line" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml"
+    sed -i "/<def-group>/a <!--comment-->" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change filepath in OVAL" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml"
+    sed -i 's/PRELINKING=no/PRELINKING=yes/' "$file"
+    regex_check="{.*'rules': \[.*'disable_prelink'.*\].*'bash': 'True'.*'ansible': 'True'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change node in OVAL" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml"
+    sed -i '/PRELINKING=/d' "$file"
+    regex_check="{.*'rules': \[.*'disable_prelink'.*\].*'bash': 'True'.*'ansible': 'True'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Remove OVAL check" {
+    file="./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml"
+    rm -f "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add new OVAL check" {
+    file="./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/oval/shared.xml"
+    mkdir -p "./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/oval/"
+    cat "./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml" > "$file"
+    regex_check="{.*'rules': \[.*'sshd_disable_rhosts'.*\].*'bash': 'True'.*'ansible': 'True'}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}

--- a/tests/json_oval.bats
+++ b/tests/json_oval.bats
@@ -23,7 +23,7 @@ prepare_repository
 @test "Change filepath in OVAL" {
     file="./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml"
     sed -i 's/PRELINKING=no/PRELINKING=yes/' "$file"
-    regex_check="{.*'rules': \[.*'disable_prelink'.*\].*'bash': 'True'.*'ansible': 'True'}"
+    regex_check='{.*"rules": \[.*"disable_prelink".*\].*"bash": "True".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -40,7 +40,7 @@ prepare_repository
 @test "Change node in OVAL" {
     file="./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml"
     sed -i '/PRELINKING=/d' "$file"
-    regex_check="{.*'rules': \[.*'disable_prelink'.*\].*'bash': 'True'.*'ansible': 'True'}"
+    regex_check='{.*"rules": \[.*"disable_prelink".*\].*"bash": "True".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -74,7 +74,7 @@ prepare_repository
     file="./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/oval/shared.xml"
     mkdir -p "./linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/oval/"
     cat "./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml" > "$file"
-    regex_check="{.*'rules': \[.*'sshd_disable_rhosts'.*\].*'bash': 'True'.*'ansible': 'True'}"
+    regex_check='{.*"rules": \[.*"sshd_disable_rhosts".*\].*"bash": "True".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_profile.bats
+++ b/tests/json_profile.bats
@@ -1,0 +1,105 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+
+@test "Change documentation_complete" {
+    file="products/rhel8/profiles/ospp.profile"
+    sed -i 's/documentation_complete: true/documentation_complete: false/' "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change title" {
+    file="products/rhel8/profiles/ospp.profile"
+    sed -i "s/title: .*/title: 'Some title'/" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add new category" {
+    file="products/rhel8/profiles/ospp.profile"
+    echo >> "$file"
+    sed -i "\$asome_category: 'with_string'" "$file"
+    regex_check="{.*'profiles': \[.*'ospp'.*\], 'product': 'rhel8'.*}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change rule (= adding new rule and removing old one)" {
+    file="products/rhel8/profiles/ospp.profile"
+    sed -i 's/disable_host_auth/enable_host_auth/' "$file"
+    regex_check="{.*'profiles': \[.*'ospp'.*\], 'product': 'rhel8'.*}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Remove profile" {
+    file="products/rhel8/profiles/ospp.profile"
+    rm -f "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add new profile" {
+    file="products/rhel8/profiles/some_profile.profile"
+    cat "products/rhel8/profiles/ospp.profile" > "$file"
+    regex_check="{.*'profiles': \[.*'some_profile'.*\], 'product': 'rhel8'.*}"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in:" && cat "$tmp_file"
+        return 1
+    fi
+}

--- a/tests/json_profile.bats
+++ b/tests/json_profile.bats
@@ -40,7 +40,7 @@ prepare_repository
     file="products/rhel8/profiles/ospp.profile"
     echo >> "$file"
     sed -i "\$asome_category: 'with_string'" "$file"
-    regex_check="{.*'profiles': \[.*'ospp'.*\], 'product': 'rhel8'.*}"
+    regex_check='{.*"profiles": \[.*"ospp".*\], "product": "rhel8".*}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -57,7 +57,7 @@ prepare_repository
 @test "Change rule (= adding new rule and removing old one)" {
     file="products/rhel8/profiles/ospp.profile"
     sed -i 's/disable_host_auth/enable_host_auth/' "$file"
-    regex_check="{.*'profiles': \[.*'ospp'.*\], 'product': 'rhel8'.*}"
+    regex_check='{.*"profiles": \[.*"ospp".*\], "product": "rhel8".*}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -90,7 +90,7 @@ prepare_repository
 @test "Add new profile" {
     file="products/rhel8/profiles/some_profile.profile"
     cat "products/rhel8/profiles/ospp.profile" > "$file"
-    regex_check="{.*'profiles': \[.*'some_profile'.*\], 'product': 'rhel8'.*}"
+    regex_check='{.*"profiles": \[.*"some_profile".*\], "product": "rhel8".*}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_python.bats
+++ b/tests/json_python.bats
@@ -1,0 +1,53 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+
+@test "Add comment" {
+    file="tests/test_suite.py"
+    sed -i "1 i # some comment" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Delete comments" {
+    file="tests/test_suite.py"
+    sed -i "/^\s*#.*/d" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change code" {
+    file="tests/test_suite.py"
+    sed -i "/^\s*subparsers\.required.*/d" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}


### PR DESCRIPTION
Adds `--output` option. With the option, output in JSON format can be printed:
```
# changed ./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
[mlysonek@localhost content-test-filtering]$ python3 content_test_filtering.py branch --output json --local --repo /home/mlysonek/SCAP/content test_branch
{'rules': ['disable_prelink'], 'product': 'rhel7', 'bash': 'False', 'ansible': 'True'}
# changed ./products/rhel8/profiles/ospp.profile
[mlysonek@localhost content-test-filtering]$ python3 content_test_filtering.py branch --output json --local --repo /home/mlysonek/SCAP/content test_branch
{'profiles': ['cui', 'ospp-mls', 'ospp'], 'product': 'rhel8'}
```

It also updates OVAL file type changes to select both remediations
```
# changed ./linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
[mlysonek@localhost content-test-filtering]$ python3 content_test_filtering.py branch --output json --local --repo /home/mlysonek/SCAP/content test_branch
{'rules': ['disable_prelink', 'grub2_enable_fips_mode'], 'product': 'rhel7', 'bash': 'True', 'ansible': 'True'}
```

Added BATS tests for JSON output show what is expected for which change.
To run the tests, I recommend setting repo_dir variable (to not clone it during test run) and running the tests within `tests/` folder`:
```
[mlysonek@localhost content-test-filtering]$ cd tests/
[mlysonek@localhost tests]$ repo_dir="/home/mlysonek/SCAP/content"
[mlysonek@localhost tests]$ export repo_dir
[mlysonek@localhost tests]$ bats json_*
 ✓ Add comment line                                                                                                                                                                                                                          
...
``` 

The JSON output behavior:

- Ansible remediation change - selects only ansible remediation for the rule
- Bash remediation change - selects only bash remediation for the rule
- OVAL check change - selects both, bash and ansible, remediations
- Python change - selects nothing
- Jinja macro - selects relevant remediations for affected rules
- Profile change - selects changed profile

Format of the JSON outputs:
```
Rule:
  {
    "rules": [ 'rule1', 'rule2', ... ],
     "product": "product name",
     "bash": "True/False",
     "ansible": "True/False"
  }

Profile:
  {
    "profiles": [ 'profile1', 'profile2', ... ],
    "product": "product name"
  }
```