### PR TITLE
Rule.yml analyzer and minor fixes

### DIFF
--- a/ctf/ContentTests.py
+++ b/ctf/ContentTests.py
@@ -154,10 +154,10 @@ class ContentTests:
         remediation_types = set()
         if diff_struct.file_type == FileType.YAML:
             remediation_types.add("ansible")
-        elif diff_struct.file_type == FileType.OVAL or diff_struct.file_type == FileType.JINJA:
-            remediation_types.add("ansible")
+        elif diff_struct.file_type == FileType.BASH:
             remediation_types.add("bash")
         else:
+            remediation_types.add("ansible")
             remediation_types.add("bash")
 
         if only_rule:

--- a/ctf/DiffStruct.py
+++ b/ctf/DiffStruct.py
@@ -87,11 +87,11 @@ class DiffStruct:
             product_name = self.get_rule_products(rule_name)
             if product_name:
                 product_name = product_name[0]
+                logger.debug("Rule %s is part of %s datastream.", rule_name, product_name)
             else:
-                msg = "The rule doesn't occur in any profile nor product."
-                self.add_rule_log(rule_name, msg)
-                return
-        logger.debug("Rule %s is part of %s datastream.", rule_name, product_name)
+                product_name = "rhel8"
+                logger.debug("Rule %s is not part of any datastream. Added default rhel8 value",
+                             rule_name, product_name)
         self.changed_rules[product_name].add(rule_name)
 
     def add_changed_profile(self, profile_name, product_name, msg=""):

--- a/ctf/analysis/RuleYmlAnalysis.py
+++ b/ctf/analysis/RuleYmlAnalysis.py
@@ -1,0 +1,58 @@
+import re
+import logging
+from deepdiff.diff import DeepDiff
+from ctf.analysis.AbstractAnalysis import AbstractAnalysis
+from ctf.constants import FileType
+
+logger = logging.getLogger("content-test-filtering.diff_analysis")
+
+
+class RuleYmlAnalysis(AbstractAnalysis):
+    def __init__(self, file_record):
+        super().__init__(file_record)
+        self.diff_struct.file_type = FileType.RULEYML
+        self.rule_name = re.match(r".+/([\w|-]+)/rule.yml$",
+                                  self.filepath).group(1)
+
+    @staticmethod
+    def can_analyse(filepath):
+        if re.match(".+/rule.yml$", filepath):
+            return True
+        return False
+
+    def process_analysis(self):
+        logger.debug("Analyzing rule.yml file %s", self.filepath)
+        logger.debug("Rule name: %s", self.rule_name)
+
+        if self.is_added():
+            msg = "Rule %s added." % self.rule_name
+            self.diff_struct.add_changed_product_by_rule(self.rule_name, msg=msg)
+            self.diff_struct.add_changed_rule(self.rule_name, msg=msg)
+            return self.diff_struct
+        elif self.is_removed():
+            msg = "Rule %s was deleted" % self.rule_name
+            self.diff_struct.add_rule_log(self.rule_name, msg)
+            return self.diff_struct
+
+        before_start = re.search(r"^\s*template:", self.content_before, re.MULTILINE)
+        after_start = re.search(r"^\s*template:", self.content_after, re.MULTILINE)
+        # No template section found, no tests selected
+        if type(before_start) is type(after_start) and before_start is None:
+            return self.diff_struct
+        # Template section either added or removed
+        elif before_start is None or after_start is None:
+            msg = "Template section has been removed/added in %s" % self.rule_name
+            self.diff_struct.add_changed_product_by_rule(self.rule_name, msg=msg)
+            self.diff_struct.add_changed_rule(self.rule_name, msg=msg)
+            return self.diff_struct
+        # Both sections with template section, do diff
+        content_before = self.content_before[before_start.start():]
+        content_after = self.content_after[after_start.start():]
+        diff = DeepDiff(content_before, content_after)
+
+        if diff:
+            msg = "Template section has been changed in %s" % self.rule_name
+            self.diff_struct.add_changed_product_by_rule(self.rule_name, msg=msg)
+            self.diff_struct.add_changed_rule(self.rule_name, msg=msg)
+
+        return self.diff_struct

--- a/ctf/constants.py
+++ b/ctf/constants.py
@@ -6,3 +6,4 @@ class FileType:
     BASH = 4
     OVAL = 5
     JINJA = 6
+    RULEYML = 7

--- a/tests/json_ruleyml.bats
+++ b/tests/json_ruleyml.bats
@@ -1,0 +1,120 @@
+#!/bin/bash
+load test_utils
+
+prepare_repository
+
+@test "Change rule title" {
+    file="linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml"
+    sed -i "s/title:.*/title: 'New title'/" "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Change variable in template" {
+    file="linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml"
+    sed -i "s/servicename:.*/servicename: new_service/" "$file"
+    regex_check='{.*"rules": \["service_avahi-daemon_disabled"\].*"bash": "True".*"ansible": "True".*}'
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in: " && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "New rule added" {
+    file="linux_os/guide/services/avahi/disable_avahi_group/some_avahi_service/rule.yml"
+    mkdir -p "linux_os/guide/services/avahi/disable_avahi_group/some_avahi_service"
+    touch "$file"
+    cat > "$file" << EOF
+title: 'New service rule'
+description: |-
+    Description of new rule.
+template:
+    name: service_disabled
+    vars:
+        servicename: some-daemon
+EOF
+    regex_check='{.*"rules": \["some_avahi_service"\].*"bash": "True".*"ansible": "True".*}'
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in: " && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Rule removed" {
+    file="linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml"
+    rm "$file"
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add template section" {
+    file="linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml"
+    cat > "$file" << EOF
+
+template:
+    name: template_name
+EOF
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "True".*"ansible": "True".*}'
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if ! grep -q "$regex_check" "$tmp_file"; then
+        echo "$regex_check not found in: " && cat "$tmp_file"
+        return 1
+    fi
+}
+
+@test "Add unknown section" {
+    file="linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml"
+    cat > "$file" << EOF
+
+unknown_section: unknown section
+EOF
+
+    git add "$file" && git commit -m "test commit" &>/dev/null
+
+    python3 $BATS_TEST_DIRNAME/../content_test_filtering.py branch --output json --local --repository "$repo_dir" test_branch &> "$tmp_file"
+
+    [ "$?" -eq 0 ]
+
+    if [ -s "$tmp_file" ]; then
+        echo "Output is not empty" && cat "$tmp_file"
+        return 1
+    fi
+}


### PR DESCRIPTION
**rule.yml analyzer**
Rule tests selected when:

- new rule.yml
- `template:` section in rule.yml changed or added

Product build selected when:

- unknown (a section that is not on list of known sections) section added

Other cases - nothing selected.

If a rule.yml uses a Jinja macro (if `{{{` in rule.yml), then CTF builds content and compares builded rule.yml contents. The main reason for this is that `yaml.safe_load` is not able to parse some rule.yml files with Jinja macros [example](https://github.com/ComplianceAsCode/content/blob/f18a52a0efd68c418f4b6b4bb181632aa04839ae/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml#L82). Unfortunately, build of all products takes several minutes.

Minor fixed:

- when a updated rule is not selected in any profile, set its product to `rhel8` - @ggbecker does it make sense?
- select only Bash (Ansible) test when a Bash (Ansible) remediation is changed. Otherwise, select both tests (Bash+Ansible)