### PR TITLE
Skip analysis of files in shared/ directory

### DIFF
--- a/ctf/analysis/AnsibleAnalysis.py
+++ b/ctf/analysis/AnsibleAnalysis.py
@@ -16,7 +16,7 @@ class AnsibleAnalysis(AbstractAnalysis):
 
     @staticmethod
     def can_analyse(filepath):
-        if re.match(r".+/ansible/\w+\.yml$", filepath):
+        if re.match(r"^(?!shared/).+/ansible/\w+\.yml$", filepath):
             return True
         return False
 

--- a/ctf/analysis/BashAnalysis.py
+++ b/ctf/analysis/BashAnalysis.py
@@ -21,7 +21,7 @@ class BashAnalysis(AbstractAnalysis):
 
     @staticmethod
     def can_analyse(filepath):
-        if re.match(r".*/bash/\w+\.sh$", filepath):
+        if re.match(r"^(?!shared/).*/bash/\w+\.sh$", filepath):
             return True
         return False
 

--- a/ctf/analysis/OVALAnalysis.py
+++ b/ctf/analysis/OVALAnalysis.py
@@ -24,7 +24,7 @@ class OVALAnalysis(AbstractAnalysis):
 
     @staticmethod
     def can_analyse(filepath):
-        if re.match(r".*/oval/\w+\.xml$", filepath):
+        if re.match(r"^(?!shared/).*/oval/\w+\.xml$", filepath):
             return True
         return False
 

--- a/ctf/analysis/RuleYmlAnalysis.py
+++ b/ctf/analysis/RuleYmlAnalysis.py
@@ -16,7 +16,7 @@ class RuleYmlAnalysis(AbstractAnalysis):
 
     @staticmethod
     def can_analyse(filepath):
-        if re.match(".+/rule.yml$", filepath):
+        if re.match("^(?!shared/).+/rule.yml$", filepath):
             return True
         return False
 


### PR DESCRIPTION
It might happened that a file from the `shared/` directory got incorrectly to analysis even though it shouldn't because it's not associated to a rule.
See https://github.com/ComplianceAsCode/content/pull/7579