### PR TITLE
Fix wrong recognizing built and raw files

### DIFF
--- a/ctf/analysis/AnsibleAnalysis.py
+++ b/ctf/analysis/AnsibleAnalysis.py
@@ -11,8 +11,12 @@ class AnsibleAnalysis(AbstractAnalysis):
     def __init__(self, file_record):
         super().__init__(file_record)
         self.diff_struct.file_type = FileType.YAML
-        self.rule_name = re.match(r".+/((?:\w|-)+)/ansible/\w+\.yml$",
-                                  self.filepath).group(1)
+        rule_name_match = re.match(r".+/((?:\w|-)+)/ansible/((?:\w|-)+)\.yml$",
+                                   self.filepath)
+        if rule_name_match.group(1) == "fixes":
+            self.rule_name = rule_name_match.group(2)
+        else:
+            self.rule_name = rule_name_match.group(1)
 
     @staticmethod
     def can_analyse(filepath):

--- a/ctf/analysis/BashAnalysis.py
+++ b/ctf/analysis/BashAnalysis.py
@@ -14,10 +14,10 @@ class BashAnalysis(AbstractAnalysis):
         self.diff_struct.file_type = FileType.BASH
         rule_name_match = re.match(r".+/((?:\w|-)+)/bash/((?:\w|-)+)\.sh$",
                                    self.filepath)
-        if rule_name_match.group(2) == "shared":
-            self.rule_name = rule_name_match.group(1)
-        else:
+        if rule_name_match.group(1) == "fixes":
             self.rule_name = rule_name_match.group(2)
+        else:
+            self.rule_name = rule_name_match.group(1)
 
     @staticmethod
     def can_analyse(filepath):

--- a/ctf/analysis/OVALAnalysis.py
+++ b/ctf/analysis/OVALAnalysis.py
@@ -17,8 +17,12 @@ class OVALAnalysis(AbstractAnalysis):
     def __init__(self, file_record):
         super().__init__(file_record)
         self.diff_struct.file_type = FileType.OVAL
-        self.rule_name = re.match(r".+/((?:\w|-)+)/oval/\w+\.xml$",
-                                  self.diff_struct.absolute_path).group(1)
+        rule_name_match = re.match(r".+/((?:\w|-)+)/oval/((?:\w|-)+)\.xml$",
+                                   self.filepath)
+        if rule_name_match.group(1) == "checks":
+            self.rule_name = rule_name_match.group(2)
+        else:
+            self.rule_name = rule_name_match.group(1)
         self.tree_before = None
         self.tree_after = None
 


### PR DESCRIPTION
Bash, Ansible, and OVAL analysis can be started either by changing "raw" file (mostly those files are in `linux_os/` directory with `shared.(xml|yml|sh)` filename) or by changing Jinja macro which invokes build and then built file analysis (files in `build/` directory).

Analysis needs to get a rule name. In the "raw" file change case, it is name of folder. In the second case, it is name of a script (e.g. `build/rhel8/fixes/bash/zipl_vsyscall_argument.sh`).

The problem was that recognizing was done based on `shared` filename. But this doesn't work when the filename is e.g. `ubuntu`. So this PR changes the recognition to a folder name - if a file is in `fixes` (or `checks` in OVAL analysis) folder, then we are analyzing built file, otherwise "raw" file is being analyzed.

Fixes #24 