### PR TITLE
Fix traceback when that was triggered when id is was empty.

### DIFF
--- a/ctf/analysis/OVALAnalysis.py
+++ b/ctf/analysis/OVALAnalysis.py
@@ -59,6 +59,8 @@ class OVALAnalysis(AbstractAnalysis):
                 file_content = f.read()
                 # Find other checks that use any id value from the check
                 for one_id in all_ids:
+                    if one_id == "":
+                        continue
                     if 'definition_ref="' + one_id not in file_content:
                         continue
                     rule_match = re.search(r"/((?:\w|-)+)/oval", content_file)


### PR DESCRIPTION
Fix:
```
DEBUG   OVALAnalysis           - network_ipv6_static_address rule affected by the change.
DEBUG   OVALAnalysis           - rule_dir rule affected by the change.
Traceback (most recent call last):
  File "/__w/content/content/./ctf/content_test_filtering.py", line 44, in <module>
    diff_structure = diff_analysis.analyse_file(file_record)
  File "/__w/content/content/ctf/ctf/diff_analysis.py", line 54, in analyse_file
    return file_analyzer.process_analysis()
  File "/__w/content/content/ctf/ctf/analysis/OVALAnalysis.py", line 244, in process_analysis
    self.analyse_oval()
  File "/__w/content/content/ctf/ctf/analysis/OVALAnalysis.py", line 217, in analyse_oval
    self.analyse_oval_change(change)
  File "/__w/content/content/ctf/ctf/analysis/OVALAnalysis.py", line 151, in analyse_oval_change
    self.update_attr_change(change)
  File "/__w/content/content/ctf/ctf/analysis/OVALAnalysis.py", line 131, in update_attr_change
    self.add_rule_test("Attribute value changed in OVAL check.")
  File "/__w/content/content/ctf/ctf/analysis/OVALAnalysis.py", line 73, in add_rule_test
    affected_rules = self.find_affected_rules()
  File "/__w/content/content/ctf/ctf/analysis/OVALAnalysis.py", line 65, in find_affected_rules
    rule_name = rule_match.group(1)
AttributeError: 'NoneType' object has no attribute 'group'
Error: Process completed with exit code 1.
```

https://github.com/ComplianceAsCode/content/runs/7179163417?check_suite_focus=true