### PR TITLE
Make the ocp4 product be prioritized over other products.

### DIFF
--- a/ctf/DiffStruct.py
+++ b/ctf/DiffStruct.py
@@ -97,7 +97,7 @@ class DiffStruct:
 
         prodtypes = re.match(r"\s*prodtype:\s*([\w|,]+)\s*", prodtype_line).group(1)
         products = prodtypes.split(",")
-        products = sorted(products, key=lambda k: (k!="rhel8", k!="rhel7", k))
+        products = sorted(products, key=lambda k: (k!="rhel8", k!="rhel7", k!="ocp4", k))
         return products
 
     def add_changed_rule(self, rule_name, product_name=None, msg=""):


### PR DESCRIPTION
when I print the products, OCP4 gets prioritized.
```
python content_test_filtering.py pr --base 11974e4aca66c26cd1fd4dd85123e1149634fec4 --remote_repo https://github.com/ComplianceAsCode/content  --verbose --rule --output json 9135
DEBUG   content_test_filtering - Getting files from 'git diff'
DEBUG   diff                   - Cloning repository to /tmp/tmpp2johog8 directory
DEBUG   diff                   - Fetched to pr-9135 branch
DEBUG   diff                   - Comparing commit 11974e4aca66c26cd1fd4dd85123e1149634fec4 with HEAD of pr-9135
DEBUG   RuleYmlAnalysis        - Analyzing rule.yml file applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
DEBUG   RuleYmlAnalysis        - Rule name: kubelet_enable_streaming_connections
DEBUG   DiffStruct             - rule.yml path - /tmp/tmpp2johog8/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
['ocp4', 'eks']
DEBUG   DiffStruct             - Rule kubelet_enable_streaming_connections is part of ocp4 datastream.
DEBUG   DiffStruct             - rule.yml path - /tmp/tmpp2johog8/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
['ocp4', 'eks']
DEBUG   DiffStruct             - Rule kubelet_enable_streaming_connections is part of ocp4 datastream.
DEBUG   TestScenarioAnalysis   - Analyzing test scenario applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/notset.fail.sh
DEBUG   TestScenarioAnalysis   - Test scenario for rule: kubelet_enable_streaming_connections
DEBUG   DiffStruct             - rule.yml path - /tmp/tmpp2johog8/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
['ocp4', 'eks']
DEBUG   DiffStruct             - Rule kubelet_enable_streaming_connections is part of ocp4 datastream.
DEBUG   DiffStruct             - rule.yml path - /tmp/tmpp2johog8/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
['ocp4', 'eks']
DEBUG   DiffStruct             - Rule kubelet_enable_streaming_connections is part of ocp4 datastream.
DEBUG   content_test_filtering - Unknown type of file applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/ocp4/e2e.yml. Analysis has not been performed for it.
{"rules": ["kubelet_enable_streaming_connections"], "product": "ocp4", "bash": "True", "ansible": "True"}
DEBUG   content_test_filtering - Finished
```