### PR TITLE
Use posix mode when parsing tokens.

### DIFF
--- a/ctf/analysis/BashAnalysis.py
+++ b/ctf/analysis/BashAnalysis.py
@@ -77,8 +77,8 @@ class BashAnalysis(AbstractAnalysis):
                 self.rule_name, msg="Template usage changed in ansible remediation.")
 
     def analyse_bash(self):
-        tokens_before = shlex.shlex(self.content_before)
-        tokens_after = shlex.shlex(self.content_after)
+        tokens_before = shlex.shlex(self.content_before, posix=True)
+        tokens_after = shlex.shlex(self.content_after, posix=True)
 
         # Read tokens from old and new bash file
         token_before = tokens_before.get_token()


### PR DESCRIPTION
`python content_test_filtering.py pr --base bf7b2cf6bc659db649ad3902762b038aedbb96de --remote_repo https://github.com/ComplianceAsCode/content  --verbose --rule 9377`

```
DEBUG   BashAnalysis           - Analyzing bash file linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
DEBUG   BashAnalysis           - Rule name: rsyslog_files_permissions
```

This string was causing problem because of the incorrect treatment of escaped double quotes.
`"s/[\"`

```
Traceback (most recent call last):
  File "/home/ggasparb/workspace/github/content-test-filtering/content_test_filtering.py", line 44, in <module>
    diff_structure = diff_analysis.analyse_file(file_record)
  File "/home/ggasparb/workspace/github/content-test-filtering/ctf/diff_analysis.py", line 54, in analyse_file
    return file_analyzer.process_analysis()
  File "/home/ggasparb/workspace/github/content-test-filtering/ctf/analysis/BashAnalysis.py", line 122, in process_analysis
    self.analyse_bash()
  File "/home/ggasparb/workspace/github/content-test-filtering/ctf/analysis/BashAnalysis.py", line 90, in analyse_bash
    token_before = tokens_before.get_token()
  File "/usr/lib64/python3.10/shlex.py", line 109, in get_token
    raw = self.read_token()
  File "/usr/lib64/python3.10/shlex.py", line 191, in read_token
    raise ValueError("No closing quotation")
ValueError: No closing quotation
```