### PR TITLE
Ignore files that only have whitespace only changes

### DIFF
--- a/ctf/analysis/AnsibleAnalysis.py
+++ b/ctf/analysis/AnsibleAnalysis.py
@@ -37,7 +37,8 @@ class AnsibleAnalysis(AbstractAnalysis):
 
     def load_diff(self):
         diff = DeepDiff(self.content_before, self.content_after)
-        if not diff:  # Nothing changed (just moved without changes)
+        if not diff or 'diff' not in diff["values_changed"]["root"]:
+            # Nothing changed (just moved without changes) or whitespace only changes
             return ""
         diff = diff["values_changed"]["root"]["diff"]
         return diff

--- a/ctf/analysis/BashAnalysis.py
+++ b/ctf/analysis/BashAnalysis.py
@@ -37,7 +37,8 @@ class BashAnalysis(AbstractAnalysis):
 
     def load_diff(self):
         diff = DeepDiff(self.content_before, self.content_after)
-        if not diff:  # Nothing changed (just moved without changes)
+        if not diff or 'diff' not in diff["values_changed"]["root"]:
+            # Nothing changed (just moved without changes) or whitespace only changes
             return ""
         diff = diff["values_changed"]["root"]["diff"]
         return diff

--- a/ctf/analysis/JinjaAnalysis.py
+++ b/ctf/analysis/JinjaAnalysis.py
@@ -205,7 +205,7 @@ class JinjaAnalysis(AbstractAnalysis):
 
     def load_diff(self):
         diff = DeepDiff(self.content_before, self.content_after)
-        if diff:
+        if diff and diff in diff["values_changed"]["root"]:
             diff = diff["values_changed"]["root"]["diff"]
         return diff
 


### PR DESCRIPTION
Add check to see if  the `diff` key is in `diff["values_changed"]["root"]` . If the file only has whitespace changes, it appears this is not set and causes key errors.

Discovered by ComplianceAsCode/content/pull/9788.