### PR TITLE
Fix a traceback

### DIFF
--- a/ctf/analysis/JinjaAnalysis.py
+++ b/ctf/analysis/JinjaAnalysis.py
@@ -205,7 +205,7 @@ class JinjaAnalysis(AbstractAnalysis):
 
     def load_diff(self):
         diff = DeepDiff(self.content_before, self.content_after)
-        if diff and diff in diff["values_changed"]["root"]:
+        if diff and "diff" in diff["values_changed"]["root"]:
             diff = diff["values_changed"]["root"]["diff"]
         return diff
 


### PR DESCRIPTION
During the CI run for PR https://github.com/ComplianceAsCode/content/pull/9951 we have hit a traceback, which is caused by missing quotes.

Addressing:

```
[jcerny@thinkpad content-test-filtering{master}]$ python3 content_test_filtering.py pr 9951
Traceback (most recent call last):
  File "/home/jcerny/work/git/content-test-filtering/content_test_filtering.py", line 44, in <module>
    diff_structure = diff_analysis.analyse_file(file_record)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/content-test-filtering/ctf/diff_analysis.py", line 54, in analyse_file
    return file_analyzer.process_analysis()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/content-test-filtering/ctf/analysis/JinjaAnalysis.py", line 294, in process_analysis
    diff = self.load_diff()
           ^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/content-test-filtering/ctf/analysis/JinjaAnalysis.py", line 208, in load_diff
    if diff and diff in diff["values_changed"]["root"]:
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unhashable type: 'DeepDiff'
```