### PR TITLE
Introduce BATS in CI and fix failing test scenarios caused by changes in CaC/content

### DIFF
--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -1,0 +1,23 @@
+name: bats-tests
+run-name: Run BATS tests
+on: pull_request
+jobs:
+  run-bats-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install -y git python3-git python3-yaml python3-jinja2 python3-deepdiff python3-pip xmldiff bats
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Checkout CaC/content
+        uses: actions/checkout@v3
+        with:
+          repository: ComplianceAsCode/content
+          path: content
+      # CTF BATS tests do commits which needs user and email defined
+      - name: Github config email
+        run: git config --global user.email "test@user.com"
+      - name: Github config user name
+        run: git config --global user.name "Test User"
+      - name: Run BATS tests
+        run: repo_dir="${GITHUB_WORKSPACE}/content/" bats tests

--- a/tests/bash.bats
+++ b/tests/bash.bats
@@ -21,8 +21,9 @@ prepare_repository
 }
 
 @test "Change indetation" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
-    sed -i "s/\s*touch \$SSSD_CONF/touch \$SSSD_CONF/" "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
+    # Add 2 extra space at beginning of each line
+    sed -i "s/\(.*\)/  \1/" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/jinja.bats
+++ b/tests/jinja.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Change sshd macro" {
-    file="./shared/macros-bash.jinja"
+    file="./shared/macros/10-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
     regex_check_1="build_product"
     regex_check_2="test_suite.py rule.*sshd_use_strong_macs"

--- a/tests/json_bash.bats
+++ b/tests/json_bash.bats
@@ -21,8 +21,9 @@ prepare_repository
 }
 
 @test "Change indetation" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
-    sed -i "s/\s*touch \$SSSD_CONF/touch \$SSSD_CONF/" "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
+    # Add 2 extra space at beginning of each line
+    sed -i "s/\(.*\)/  \1/" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_jinja.bats
+++ b/tests/json_jinja.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Change sshd macro" {
-    file="./shared/macros-bash.jinja"
+    file="./shared/macros/10-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
     regex_check_1='{.*"rules": \[.*"sshd_use_strong_ciphers".*\].*"bash": "True".*"ansible": "False".*}'
     regex_check_2='{.*"rules": \[.*"sshd_use_strong_macs".*\].*"bash": "True".*"ansible": "False".*}'

--- a/tests/json_python.bats
+++ b/tests/json_python.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Add comment" {
-    file="tests/test_suite.py"
+    file="tests/automatus.py"
     sed -i "1 i # some comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -21,7 +21,7 @@ prepare_repository
 }
 
 @test "Delete comments" {
-    file="tests/test_suite.py"
+    file="tests/automatus.py"
     sed -i "/^\s*#.*/d" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -37,7 +37,7 @@ prepare_repository
 }
 
 @test "Change code" {
-    file="tests/test_suite.py"
+    file="tests/automatus.py"
     sed -i "/^\s*subparsers\.required.*/d" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null

--- a/tests/json_test-scenario.bats
+++ b/tests/json_test-scenario.bats
@@ -4,7 +4,7 @@ load test_utils
 prepare_repository
 
 @test "Add comment line" {
-    file="./linux_os/guide/system/auditing/policy_rules/audit_delete_failed/tests/correct_rules.pass.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/bad_permissions.fail.sh"
     sed -i "\$a#comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -20,9 +20,9 @@ prepare_repository
 }
 
 @test "Update test scenario" {
-    file="./linux_os/guide/system/auditing/policy_rules/audit_delete_failed/tests/correct_rules.pass.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/bad_permissions.fail.sh"
     sed -i "\$a echo \$x" "$file"
-    regex_check='{.*"rules": \["audit_delete_failed"\].*"bash": "True".*"ansible": "True"}'
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "True".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -37,9 +37,9 @@ prepare_repository
 }
 
 @test "Update test metadata" {
-    file="./linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh"
-    sed -i "s/\(# platform = .*\)/\1, some_platform/g" "$file"
-    regex_check='{.*"rules": \["chronyd_specify_remote_server"\].*"bash": "True".*"ansible": "True"}'
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/bad_permissions.fail.sh"
+    sed -i "1i # platform = fedora" "$file"
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "True".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -54,9 +54,9 @@ prepare_repository
 }
 
 @test "New test scenario" {
-    file="./linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/new_test.pass.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/new_test.pass.sh"
     touch "$file"
-    regex_check='{.*"rules": \["chronyd_specify_remote_server"\].*"bash": "True".*"ansible": "True"}'
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "True".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -71,7 +71,7 @@ prepare_repository
 }
 
 @test "Test removed" {
-    file="./linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/bad_permissions.fail.sh"
     rm "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null

--- a/tests/python.bats
+++ b/tests/python.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Add comment" {
-    file="tests/test_suite.py"
+    file="tests/automatus.py"
     sed -i "1 i # some comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -21,7 +21,7 @@ prepare_repository
 }
 
 @test "Delete comments" {
-    file="tests/test_suite.py"
+    file="tests/automatus.py"
     sed -i "/^\s*#.*/d" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -37,7 +37,7 @@ prepare_repository
 }
 
 @test "Change code" {
-    file="tests/test_suite.py"
+    file="tests/automatus.py"
     sed -i "/^\s*subparsers\.required.*/d" "$file"
     regex_check="ctest"
 


### PR DESCRIPTION
Enable GH Workflow running tests with BATS.
Adjust test scenarios to reflect changes in CaC/content. In tests, rely now on `rpm_verify_permissions` because this rule is good for the change testing as it's very specific and most likely won't be removed/templated.