### PR TITLE
Filter updated control files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Both options have common optional arguments:
                         Output from the tool.
   --profile             Print only profile tests.
   --rule                Print only rule tests.
+  --control             Print the updates of control files.
 ```
 
 ### Remote vs local analysis

--- a/content_test_filtering.py
+++ b/content_test_filtering.py
@@ -43,9 +43,10 @@ if __name__ == '__main__':
         if file_record["filepath"].startswith(".github"):
             continue
 
-        # Filter the updated control files
+        # Filter the updated control files for syncing OSCAL catalog
         if "controls/" in file_record["filepath"]:
-            controls_files.append(file_record["filepath"])
+            control_file = file_record["filepath"].split('/')[-1]
+            controls_files.append(control_file)
 
         try:
             diff_structure = diff_analysis.analyse_file(file_record)
@@ -62,16 +63,10 @@ if __name__ == '__main__':
     list_of_tests = connect_to_labels.get_labels(tests, options.output)
     if options.output == "json":
         logs.print_json(list_of_tests)
+        logger.debug(f"The updated controls: {controls_files}")
+        if controls_files:
+            controls_updates = [{"controls": controls_files}]
+            logs.print_json(controls_updates)
     else:
         logs.print_all_logs(list_of_tests, output_format=options.output_format)
-    # Save the updated controls to a file for syncing OSCAL catalog
-    logger.debug(f"The updated controls: {controls_files}")
-    if options.output == "json":
-        controls_updates = {"controls": controls_files}
-        try:
-            with open('controls_updates.json', 'w', encoding='utf-8') as file:
-                json.dump(controls_updates, file, ensure_ascii=False, indent=4)
-            logger.debug("Controls saved to controls_updates.json successfully.")
-        except Exception as e:
-            logger.error(f"Error saving controls updates: {e}")
     logger.debug("Finished")

--- a/content_test_filtering.py
+++ b/content_test_filtering.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-import logging
+import json, logging
 from sys import stderr
 from ctf import cli, diff_analysis, connect_to_labels, ContentTests, DiffLogging
 from ctf.diff import git_wrapper
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     changed_files = git_wrapper.git_diff_files(options.base_branch,
                                                new_branch=options.branch,
                                                pr_number=options.pr_number)
-
+    controls_files = []
     # Analyze each file separately and make set of tests for each one
     while True:
         if not changed_files:  # Finish when all files are analysed
@@ -42,6 +42,10 @@ if __name__ == '__main__':
 
         if file_record["filepath"].startswith(".github"):
             continue
+
+        # Filter the updated control files
+        if "controls/" in file_record["filepath"]:
+            controls_files.append(file_record["filepath"])
 
         try:
             diff_structure = diff_analysis.analyse_file(file_record)
@@ -55,11 +59,19 @@ if __name__ == '__main__':
         already_analysed.append(file_record["filepath"])
         # If change affected any other file -> analyse it
         changed_files.extend(diff_structure.affected_files)
-
     list_of_tests = connect_to_labels.get_labels(tests, options.output)
     if options.output == "json":
         logs.print_json(list_of_tests)
     else:
         logs.print_all_logs(list_of_tests, output_format=options.output_format)
-
+    # Save the updated controls to a file for syncing OSCAL catalog
+    logger.debug(f"The updated controls: {controls_files}")
+    if options.output == "json":
+        controls_updates = {"controls": controls_files}
+        try:
+            with open('controls_updates.json', 'w', encoding='utf-8') as file:
+                json.dump(controls_updates, file, ensure_ascii=False, indent=4)
+            logger.debug("Controls saved to controls_updates.json successfully.")
+        except Exception as e:
+            logger.error(f"Error saving controls updates: {e}")
     logger.debug("Finished")

--- a/content_test_filtering.py
+++ b/content_test_filtering.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     if options.output == "json":
         logs.print_json(list_of_tests)
         logger.debug(f"The updated controls: {controls_files}")
-        if controls_files:
+        if controls_files and options.control_output:
             controls_updates = [{"controls": controls_files}]
             logs.print_json(controls_updates)
     else:

--- a/ctf/cli.py
+++ b/ctf/cli.py
@@ -37,6 +37,8 @@ def parse_args():
                                action="store_true", help="Print only profile tests.")
     common_parser.add_argument("--rule", dest="rule_output", default=False,
                                action="store_true", help="Print only rule tests.")
+    common_parser.add_argument("--control", dest="control_output", default=False,
+                               action="store_true", help="Print control updates.")
 
     parser.set_defaults(pr_number=None, branch=None)
 


### PR DESCRIPTION
The feature is trying to filter the updated control files.
The aim is to sync the control file updates to the OSCAL catalog via [trestlebot tool](https://github.com/complytime/trestle-bot).  The `sync-cac-content catalog` input is the CaC content control file. So if there are any updates of the control file in CaC content,  it will trigger the sync to update the OSCAL catalog.

How to test:
`python content_test_filtering.py pr --base 4266a65aa118d6840c05d33d40a1612ad10bbf1c --remote_repo https://github.com/ComplianceAsCode/content --verbose --rule --profile --output  json 13176`


